### PR TITLE
Use `inputId` in snap location

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -8,7 +8,7 @@ build_call <- function(type,arg,opts,ui, ...){
 
 }
 
-call_contents <- function(type = c('preview','download'),arg, save_dir){
+call_contents <- function(type = c('preview','download'),arg, save_dir, inputId){
 
   switch(type,
          'preview' = {
@@ -27,10 +27,10 @@ call_contents <- function(type = c('preview','download'),arg, save_dir){
            sprintf('
            var img = canvas.toDataURL();
            Shiny.setInputValue(
-             `snap:snapper`,
+             `%s_snap:snapper`,
              { image: img, filename : "%s", dir : "%s" },
              { priority : "event" }
-           );', arg, URLencode(save_dir))
+           );', inputId, arg, URLencode(save_dir))
          })
 
 }

--- a/R/buttons.R
+++ b/R/buttons.R
@@ -14,8 +14,8 @@
 #' @param icon icon to pass use for in the link objects, Default: 'camera'
 #' @param save_dir directory on the server where the image should be saved, relative
 #' to the shiny app's working directory. If saving the image is successful,
-#' `input$snap` will contain the full path to the image. If not,
-#' `input$snap` will contain an empty string (`""`).
+#' `input$[inputId]_snap` will contain the full path to the image. If not,
+#' `input$[inputId]_snap` will contain an empty string (`""`).
 #' @details Use [config][config] to define the configuration options
 #' @return shiny.tag
 #' @examples
@@ -192,7 +192,8 @@ save_button <- function(inputId = 'btn-Save-Html2Image',
       arg = filename,
       opts = opts,
       ui = ui,
-      save_dir = save_dir
+      save_dir = save_dir,
+      inputId = inputId
     )
   )
 }
@@ -216,7 +217,8 @@ save_link <- function(inputId = 'btn-Save-Html2Image',
       arg = filename,
       opts = opts,
       ui = ui,
-      save_dir = save_dir
+      save_dir = save_dir,
+      inputId = inputId
     )
   )
 }


### PR DESCRIPTION
This PR enables `save_button()` and `save_link()` to work in shiny modules by prefixing `input$snap` with the `inputId` of the button/link.

closes #10

This is a version of the reprex in #10 modified to work:

```r
library(shiny)
library(snapper)

module_ui <- function(id) {
  ns <- NS(id)
  tagList(
    sliderInput(ns("obs"),
                "Number of observations:",
                min = 0,
                max = 1000,
                value = 500),
    plotOutput(ns("distPlot")),
    save_button(inputId = ns("save_button"), ui = paste0("#", ns("distPlot")), save_dir = tempdir()), # set the inputId here
    verbatimTextOutput(ns("file_location"))
  )
}

mod_server <- function(id) {
  moduleServer(id, function(input, output, session){
    output$distPlot <- renderPlot({
      hist(rnorm(input$obs))
    })
    
    output$file_location <- renderPrint(cat(input$save_button_snap)) # added the inputId here
  })
}

shinyApp(
  ui = fluidPage(
    load_snapper(),
    module_ui("mod")
  ),
  server = function(input, output) {
    mod_server("mod")
  }
)
```